### PR TITLE
fix: search icon misalignment issue in search input

### DIFF
--- a/contributors.html
+++ b/contributors.html
@@ -193,7 +193,7 @@
       .search-icon {
         position: absolute;
         left: 1rem;
-        top: 50%;
+        top: 30%;
         transform: translateY(-50%);
         color: var(--text-light);
       }


### PR DESCRIPTION
This pull request fixes the vertical misalignment of the search icon inside the search bar.

Before:
<img width="400" height="172" alt="Screenshot 2025-11-02 165132" src="https://github.com/user-attachments/assets/ab2d61b5-00d8-4687-9793-adf1736b0ee1" />

After:
<img width="520" height="138" alt="Screenshot 2025-11-02 165152" src="https://github.com/user-attachments/assets/4f0ca061-7f10-460c-9093-55f939927223" />
