### PR TITLE
Remove large top margin from .section-header to eliminate unwanted gap above sections

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1154,7 +1154,8 @@ html {
 
 .section-header {
   text-align: center;
-  margin-top: 600px;
+  /* Removed large top margin that created an unwanted gap above sections */
+  margin-top: 0;
 }
 
 .section-header h2 {


### PR DESCRIPTION
Fixes issue:- #166 
## Description
Remove large top margin from .section-header to eliminate unwanted gap above sections

see the below image, no spaces above the Our Premium Services section

<img width="1893" height="869" alt="image" src="https://github.com/user-attachments/assets/e8937fa7-ab9a-45de-9207-060714b1d68a" />
