### PR TITLE
Raise chatbot modal overlay z-index to 1002 to ensure it appears above floating elements

### DIFF
--- a/css/components/chatbot-modal.css
+++ b/css/components/chatbot-modal.css
@@ -11,7 +11,7 @@
     right: 0;
     bottom: 0;
     background: rgba(0, 0, 0, 0.4);
-    z-index: 999;
+    z-index: 1002;
     align-items: flex-end;
     justify-content: flex-start;
     padding: 20px;


### PR DESCRIPTION
Fixes issue:- #197 


