### PR TITLE
feat: Enhance typography and color contrast for dark and light modes

### DIFF
--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -27,6 +27,11 @@ body {
   color: var(--footer-text);
 }
 
+/* Ensure Region heading is visible on dark background */
+body[data-theme="dark"] .region-section h2 {
+  color: #ffffff !important;
+}
+
 /* Contact CTA Section */
 .contact-cta {
   background: linear-gradient(135deg, #1a1a1a 0%, #0f1115 100%);

--- a/css/light-mode.css
+++ b/css/light-mode.css
@@ -156,3 +156,24 @@ body {
   box-shadow: 0 8px 20px rgba(255, 99, 71, 0.3) !important;
 }
 
+/* Testimonials intro paragraph on light background */
+body[data-theme="light"] .testimonials-section .section-title p {
+  color: #2d2d2d !important;
+}
+
+/* Footer text contrast in light theme */
+body[data-theme="light"] .footer,
+body[data-theme="light"] #footer-container .footer {
+  color: #222222 !important;
+}
+body[data-theme="light"] .footer .footer-about p,
+body[data-theme="light"] .footer .footer-links a,
+body[data-theme="light"] .footer .contact-info li,
+body[data-theme="light"] .footer .footer-bottom-content,
+body[data-theme="light"] .footer .footer-bottom-content .copyright,
+body[data-theme="light"] .footer .footer-bottom-links a,
+body[data-theme="light"] .footer .payment-methods i,
+body[data-theme="light"] .footer .footer-brand {
+  color: #333333 !important;
+}
+

--- a/css/styles.css
+++ b/css/styles.css
@@ -6,6 +6,15 @@
   font-style: normal;
 }
 
+/* Map Medium (500) to Regular as an interim step */
+@font-face {
+  font-family: "Poppins";
+  src: url("../assets/fonts/Poppins-Regular.woff2") format("woff2"),
+    url("../assets/fonts/Poppins-Regular.woff") format("woff");
+  font-weight: 500;
+  font-style: normal;
+}
+
 @font-face {
   font-family: "Poppins";
   src: url("../assets/fonts/Poppins-Bold.woff2") format("woff2"),
@@ -14,10 +23,37 @@
   font-style: normal;
 }
 
+/* Map SemiBold (600) to Bold as an interim step */
+@font-face {
+  font-family: "Poppins";
+  src: url("../assets/fonts/Poppins-Bold.woff2") format("woff2"),
+    url("../assets/fonts/Poppins-Bold.woff") format("woff");
+  font-weight: 600;
+  font-style: normal;
+}
+
 /* ========================================
    COLOR PALETTE - Standardized & Accessible
    ======================================== */
 :root {
+  /* Typography Scale */
+  --font-size-base: 16px;
+  --line-height-base: 1.6;
+  --line-height-tight: 1.25;
+  --line-height-loose: 1.8;
+
+  --h1-size: clamp(2rem, 4vw + 1rem, 3rem);
+  --h2-size: clamp(1.75rem, 3vw + 0.75rem, 2.25rem);
+  --h3-size: clamp(1.5rem, 2vw + 0.5rem, 1.75rem);
+  --h4-size: 1.25rem;
+  --h5-size: 1.125rem;
+  --h6-size: 1rem;
+
+  --weight-regular: 400;
+  --weight-medium: 500;
+  --weight-semibold: 600;
+  --weight-bold: 700;
+
   /* Primary Colors */
   --color-primary: #ff6347;
   --color-primary-dark: #ff4500;
@@ -63,8 +99,24 @@
 
 body {
   font-family: "Poppins", sans-serif;
+  font-size: var(--font-size-base);
+  line-height: var(--line-height-base);
   overflow-x: hidden;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
+
+/* Baseline typography */
+h1, .h1 { font-size: var(--h1-size); line-height: var(--line-height-tight); font-weight: var(--weight-bold); }
+h2, .h2 { font-size: var(--h2-size); line-height: var(--line-height-tight); font-weight: var(--weight-bold); }
+h3, .h3 { font-size: var(--h3-size); line-height: 1.3; font-weight: var(--weight-semibold); }
+h4, .h4 { font-size: var(--h4-size); line-height: 1.35; font-weight: var(--weight-semibold); }
+h5, .h5 { font-size: var(--h5-size); line-height: 1.4; font-weight: var(--weight-medium); }
+h6, .h6 { font-size: var(--h6-size); line-height: 1.45; font-weight: var(--weight-medium); }
+
+p, li { line-height: var(--line-height-base); }
+small { line-height: 1.4; }
+strong { font-weight: var(--weight-bold); }
 
 /* General Reset */
 * {


### PR DESCRIPTION
## Which issue does this PR close?
#384 

## What changes are included in this PR?

Typography baseline added: new weight mappings (500/600), standardized CSS variables for heading sizes, and improved default line-heights. Let me know if you’d like adjustments (e.g., smaller h1 clamp or different paragraph leading) or to propagate to component-specific overrides.

Fix dark theme heading for Region-Wise Presence.
Fix light theme paragraph under testimonials.
Improve footer text contrast in light theme.

