### PR TITLE
Get In touch Theme toggle issue on home page

### DIFF
--- a/frontend/css/dark-mode.css
+++ b/frontend/css/dark-mode.css
@@ -53,6 +53,72 @@ body[data-theme="dark"] .region-section h2 {
   color: #ffffff !important;
 }
 
+/* Contact Form "Get In touch"- Dark Theme */
+body[data-theme="dark"] .cta-form-box {
+  background: linear-gradient(145deg, rgba(30, 30, 30, 0.95), rgba(20, 20, 20, 0.95)) !important;
+  border: 1px solid rgba(255, 107, 61, 0.3) !important;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.5), 0 0 30px rgba(255, 107, 61, 0.15) !important;
+}
+
+body[data-theme="dark"] .form-header h3 {
+  color: #ffffff !important;
+}
+
+body[data-theme="dark"] .form-header p {
+  color: #ff6b35 !important;
+}
+/* Contact Form Input Fields - Dark Theme */
+body[data-theme="dark"] .input-group {
+  background: rgba(255, 255, 255, 0.05) !important;
+  border: 1px solid rgba(255, 255, 255, 0.1) !important;
+  border-radius: 8px !important;
+}
+
+body[data-theme="dark"] .input-group i {
+  color: rgba(255, 255, 255, 0.5) !important;
+}
+
+body[data-theme="dark"] .input-group:focus-within i {
+  color: #ff6b35 !important;
+}
+
+body[data-theme="dark"] .input-group input,
+body[data-theme="dark"] .input-group select {
+  background: transparent !important;
+  color: #ffffff !important;
+  border: none !important;
+  outline: none !important;
+}
+
+body[data-theme="dark"] .input-group input::placeholder {
+  color: rgba(255, 255, 255, 0.5) !important;
+}
+
+body[data-theme="dark"] .input-group select {
+  background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6 9 12 15 18 9'%3e%3c/polyline%3e%3c/svg%3e") !important;
+  background-repeat: no-repeat !important;
+  background-position: right 8px center !important;
+  background-size: 16px !important;
+  appearance: none !important;
+  -webkit-appearance: none !important;
+  -moz-appearance: none !important;
+}
+
+body[data-theme="dark"] .input-group select option {
+  background: #1a1a1a !important;
+  color: white !important;
+  padding: 12px !important;
+}
+
+/* Remove white background on autofill */
+body[data-theme="dark"] .input-group input:-webkit-autofill,
+body[data-theme="dark"] .input-group input:-webkit-autofill:hover,
+body[data-theme="dark"] .input-group input:-webkit-autofill:focus {
+  -webkit-text-fill-color: #ffffff !important;
+  -webkit-box-shadow: 0 0 0px 1000px transparent inset !important;
+  transition: background-color 5000s ease-in-out 0s !important;
+}
+
 /* Features Section */
 .features {
   background: var(--bg);


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #421 

## What changes are included in this PR?

This PR solves the toggle theme issue of "Get In Touch" card in home page 

## Are these changes tested?

Yes

## Are there any user-facing changes?

The dark is bring applied to "Get In Touch" Card when toggle 


## Screenshots (if Applicable)
Before:
<img width="1920" height="1080" alt="Screenshot (61)" src="https://github.com/user-attachments/assets/ad20789c-56ee-46e6-9da6-cae4f17c4bdf" />
After:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b626b2b3-30c8-4921-83b0-8cf40b732adf" />
