### PR TITLE
Fix: Footer not loading correctly on FAQ page

### DIFF
--- a/frontend/pages/faq.html
+++ b/frontend/pages/faq.html
@@ -572,6 +572,8 @@
     <script src="../js/modules/back-to-top-button.js"></script>
     <script src="../js/modules/backtoBottom.js"></script>
     <script src="../js/modules/scroll-animations.js"></script>
+<!-- Bug: fix the footer on FAQ page  -->
+    <script src="../js/modules/footer-loader.js"></script>
 
     <!-- Back to Top Button -->
     <button class="back-to-top" id="backToTop">


### PR DESCRIPTION
## what i have done 
the footer was broken in FAQ page so i fixed it 
## Screenshots 
## Before
<img width="944" height="473" alt="image" src="https://github.com/user-attachments/assets/6cac453e-f9dc-4589-9bde-71afe28fa646" />

## After
<img width="938" height="474" alt="image" src="https://github.com/user-attachments/assets/3b4104df-f197-4f07-9c11-2b6cea66038b" />
@Nikhilrsingh 