### PR TITLE
 Member image position fixed (both for desktop as well as mobile view)

### DIFF
--- a/frontend/css/components/about.css
+++ b/frontend/css/components/about.css
@@ -112,6 +112,18 @@
   display: block;
   transition: transform 0.6s ease, filter 0.4s ease;
 }
+/* Member image position fixed (both for desktop as well as mobile view) */
+.team-grid>.about-team-flip-card:nth-of-type(2) .about-member-image-wrapper img{
+  object-position: center 20%;
+}
+.team-grid>.about-team-flip-card:nth-of-type(3) .about-member-image-wrapper img {
+  object-position: center 5%;
+}
+.team-grid>.about-team-flip-card:nth-of-type(1) .about-member-image-wrapper img,
+.team-grid>.about-team-flip-card:nth-of-type(4) .about-member-image-wrapper img {
+  object-position: center 35%;
+}
+
 
 .about-member-image-wrapper:hover img {
   transform: scale(1.08);


### PR DESCRIPTION



- Closes #659 

**Rationale for this change**
On mobile and smaller screen sizes, the 2nd and 3rd team member images on the About page had their faces partially cut due to a uniform object-fit: cover behavior. This negatively impacted visual clarity and overall user experience.
This change was introduced to ensure better face visibility for the affected images while preserving the existing layout, animations, and design consistency.

**What changes are included in this PR?**
Ensured a consistent portrait aspect ratio for team member image containers.
Used object-fit: cover with face-safe positioning.
Adjusted object-position specifically for the 2nd and 3rd team member images to prevent face cropping on mobile devices.
Scoped the fix only to the affected elements, with no impact on other cards or layouts.

**Are these changes tested?**
Yes. The changes were tested manually across multiple screen sizes, including mobile, tablet, and desktop, to verify proper image alignment and responsive behavior.

**Are there any user-facing changes?**
Yes. Team member images on the About page now display faces more clearly on mobile and smaller screens, improving visual clarity and user experience.



**## Screenshots** 
before
<img width="674" height="1536" alt="image" src="https://github.com/user-attachments/assets/bedaf406-caf9-41c8-b4b5-7c94d7618d5f" />
after
<img width="674" height="1536" alt="image" src="https://github.com/user-attachments/assets/226aa48e-9c30-4d7b-a1a4-091298cc5612" />
