### PR TITLE
Fix: fixed the wrong color contast of nav icons of active nav links

### DIFF
--- a/frontend/css/components/navbar.css
+++ b/frontend/css/components/navbar.css
@@ -1423,3 +1423,11 @@ body {
   background: #444444 !important;
   box-shadow: 0 0 10px rgba(255, 106, 61, 0.35) !important;
 }
+
+.nav-link.active i,
+.dropdown-nav.active > .nav-link i,
+.dropdown-nav.active > [data-dropdown-btn] i,
+.mobile-nav-link.active i {
+  color: #ffffff !important;
+  -webkit-text-fill-color: #ffffff !important;;
+}


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #663

## What changes are included in this PR?

Changed the color of nav icons to be white when the nav link is active, fixing color contrast issue.

## Are these changes tested?

Yes.

## Are there any user-facing changes?

No.

## Screenshots
Before
<img width="1352" height="96" alt="Screenshot 2026-01-02 180053" src="https://github.com/user-attachments/assets/2580b224-e33d-4b7f-8c36-b5803f442703" />

---

After
<img width="1356" height="98" alt="Screenshot 2026-01-03 003826" src="https://github.com/user-attachments/assets/94cccf6a-8a20-4500-8843-c895517cc9c2" />

