### PR TITLE
fix: Corrected the overlapping clock-timer with that of navbar in home page

### DIFF
--- a/frontend/css/components/digital-clock.css
+++ b/frontend/css/components/digital-clock.css
@@ -1,7 +1,7 @@
 #mac-clock {
   position: fixed;
   top:  3px;
-  right: 20px;
+  right: 40px;
   font-size: 15px;
   font-weight: 500;
   color: #f5f5f7;

--- a/frontend/css/components/navbar.css
+++ b/frontend/css/components/navbar.css
@@ -193,6 +193,9 @@ body {
 /* When scrolled, main navbar moves to top */
 .navbar.scrolled {
   top: 0;
+  display: flex;
+  align-items: end;
+  height: 105px;
 }
 
 /* Logo Styles - Fixed alignment */


### PR DESCRIPTION
…e page

## Which issue does this PR close?

- Closes #661 

The Clock Timer that exists in the top right corner seems to be working well but upon scrolling down the website, the clock timer overlaps the Navbar region

## Rationale for this change

- Overlapping of different components in the webpage bring about an inconvenience to the user in accessing the below placed access buttons such as login button.
- Presence of overlapping brings about a though of poor developemnt of webpage in the minds of the user/viewer

## What changes are included in this PR?

Increase the height of the current navbar only upon scrollong the webpage thereby providing extra upper space to accomodate the clock timer
<code>.navbar.scrolled {
top: 0;
display:flex;
align-items:end;
height:105px;
}</code>

Align the digital clock corner with that of the below placed login button for better visual look. This is made possible by taking the <code>position:fixed;</code> property and then tuning the position using <code>top</code> and <code>right</code>
<code>#mac-clock {
position: fixed;
top:  3px;
right: 40px;
}</code>

## Are these changes tested?

Yes

## Are there any user-facing changes?

No


<img width="587" height="61" alt="timer-overlap-bug" src="https://github.com/user-attachments/assets/816df858-8e88-4d4d-9595-764c54192660" />

 IMAGE SHOWING THE OVERLAPPING OF THE CLOCK-TIMER WITH THAT OF THE NAVBAR 


## Screenshots (if Applicable)
<img width="571" height="78" alt="timer-overlap-fixed" src="https://github.com/user-attachments/assets/abef72d5-c978-48ad-8821-c8cc8442521e" />

 IMAGE SHOWING THE BUG BEING FIXED 

