### PR TITLE
Fix dark mode text visibility and pricing CTA background

### DIFF
--- a/frontend/css/dark-mode.css
+++ b/frontend/css/dark-mode.css
@@ -15,31 +15,25 @@ body[data-theme="dark"] {
   --color-gray-200: #d2c4c4;
   --color-gray-300: #6e6c6c;
   --color-gray-400: #555555;
-}
-
-body {
   background: var(--bg);
   color: var(--text);
 }
 
-.footer {
+/* Footer */
+body[data-theme="dark"] .footer {
   background: var(--footer-bg);
   color: var(--footer-text);
 }
 
-/* Ensure Region heading is visible on dark background */
+/* Region section */
 body[data-theme="dark"] .region-section {
   background: var(--bg, #0f1115) !important;
 }
-
 body[data-theme="dark"] .region-section h2 {
   color: #ffffff !important;
 }
 
-/*
-   Navbar & Middle Navbar - Dark Theme Overrides
-   Ensure navigation text is readable (white) in dark mode
-*/
+/* Navbar & middle navbar */
 body[data-theme="dark"] .upbar,
 body[data-theme="dark"] .navbar,
 body[data-theme="dark"] .dropdown-menu,
@@ -48,26 +42,36 @@ body[data-theme="dark"] .mobile-nav {
   border-color: #444 !important;
 }
 
-body[data-theme="dark"] .upbar-btn,
-body[data-theme="dark"] .upbar-btn span,
-body[data-theme="dark"] .upbar-btn i,
-body[data-theme="dark"] .nav-link,
-body[data-theme="dark"] .nav-link i,
-body[data-theme="dark"] .nav-right-section,
-body[data-theme="dark"] .nav-actions,
-body[data-theme="dark"] .login-btn,
-body[data-theme="dark"] .enquiry-link,
-body[data-theme="dark"] .mobile-nav-link,
-body[data-theme="dark"] .mobile-nav-link i {
+body[data-theme="dark"]
+  .upbar-btn,
+body[data-theme="dark"]
+  .upbar-btn span,
+body[data-theme="dark"]
+  .upbar-btn i,
+body[data-theme="dark"]
+  .nav-link,
+body[data-theme="dark"]
+  .nav-link i,
+body[data-theme="dark"]
+  .nav-right-section,
+body[data-theme="dark"]
+  .nav-actions,
+body[data-theme="dark"]
+  .login-btn,
+body[data-theme="dark"]
+  .enquiry-link,
+body[data-theme="dark"]
+  .mobile-nav-link,
+body[data-theme="dark"]
+  .mobile-nav-link i {
   color: #ffffff !important;
 }
 
 body[data-theme="dark"] .search-bar input {
   color: #ffffff !important;
 }
-
 body[data-theme="dark"] .search-bar input::placeholder {
-  color: rgba(255,255,255,0.6) !important;
+  color: rgba(255, 255, 255, 0.6) !important;
 }
 
 body[data-theme="dark"] .middle-navbar {
@@ -75,71 +79,71 @@ body[data-theme="dark"] .middle-navbar {
   border-bottom: 1px solid #444 !important;
 }
 
-body[data-theme="dark"] .middle-contact-item,
-body[data-theme="dark"] .contact-number,
-body[data-theme="dark"] .contact-sub {
+body[data-theme="dark"]
+  .middle-contact-item,
+body[data-theme="dark"]
+  .contact-number,
+body[data-theme="dark"]
+  .contact-sub {
   color: #ffffff !important;
 }
 
-/* Contact CTA Section */
-.contact-cta {
+/* Contact CTA section */
+body[data-theme="dark"] .contact-cta {
   background: linear-gradient(135deg, #1a1a1a 0%, #0f1115 100%);
 }
-
-.cta-text h2 {
+body[data-theme="dark"] .contact-cta .cta-text h2 {
   color: #ffffff !important;
 }
-
-.cta-text p {
+body[data-theme="dark"] .contact-cta .cta-text p {
   color: #f0f0f0 !important;
 }
-
-.feature span {
+body[data-theme="dark"] .contact-cta .feature span {
   color: #ffffff !important;
 }
 
-/* Contact Form "Get In touch"- Dark Theme */
+/* Contact form (Get in touch) */
 body[data-theme="dark"] .cta-form-box {
   background: linear-gradient(145deg, rgba(30, 30, 30, 0.95), rgba(20, 20, 20, 0.95)) !important;
   border: 1px solid rgba(255, 107, 61, 0.3) !important;
-  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.5), 0 0 30px rgba(255, 107, 61, 0.15) !important;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.5),
+    0 0 30px rgba(255, 107, 61, 0.15) !important;
 }
-
-body[data-theme="dark"] .form-header h3 {
+body[data-theme="dark"] .cta-form-box .form-header h3 {
   color: #ffffff !important;
 }
-
-body[data-theme="dark"] .form-header p {
+body[data-theme="dark"] .cta-form-box .form-header p {
   color: #ff6b35 !important;
 }
-/* Contact Form Input Fields - Dark Theme */
-body[data-theme="dark"] .input-group {
+
+body[data-theme="dark"] .cta-form-box .input-group {
   background: rgba(255, 255, 255, 0.05) !important;
   border: 1px solid rgba(255, 255, 255, 0.1) !important;
   border-radius: 8px !important;
 }
-
-body[data-theme="dark"] .input-group i {
+body[data-theme="dark"] .cta-form-box .input-group i {
   color: rgba(255, 255, 255, 0.5) !important;
 }
-
-body[data-theme="dark"] .input-group:focus-within i {
+body[data-theme="dark"] .cta-form-box .input-group:focus-within i {
   color: #ff6b35 !important;
 }
-
-body[data-theme="dark"] .input-group input,
-body[data-theme="dark"] .input-group select {
+body[data-theme="dark"] .cta-form-box .input-group input,
+body[data-theme="dark"] .cta-form-box .input-group select {
   background: transparent !important;
   color: #ffffff !important;
   border: none !important;
   outline: none !important;
 }
-
-body[data-theme="dark"] .input-group input::placeholder {
+body[data-theme="dark"]
+  .cta-form-box
+  .input-group
+  input::placeholder {
   color: rgba(255, 255, 255, 0.5) !important;
 }
-
-body[data-theme="dark"] .input-group select {
+body[data-theme="dark"]
+  .cta-form-box
+  .input-group
+  select {
   background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6 9 12 15 18 9'%3e%3c/polyline%3e%3c/svg%3e") !important;
   background-repeat: no-repeat !important;
   background-position: right 8px center !important;
@@ -148,238 +152,257 @@ body[data-theme="dark"] .input-group select {
   -webkit-appearance: none !important;
   -moz-appearance: none !important;
 }
-
-body[data-theme="dark"] .input-group select option {
+body[data-theme="dark"]
+  .cta-form-box
+  .input-group
+  select
+  option {
   background: #1a1a1a !important;
   color: white !important;
   padding: 12px !important;
 }
-
-/* Remove white background on autofill */
-body[data-theme="dark"] .input-group input:-webkit-autofill,
-body[data-theme="dark"] .input-group input:-webkit-autofill:hover,
-body[data-theme="dark"] .input-group input:-webkit-autofill:focus {
+body[data-theme="dark"]
+  .cta-form-box
+  .input-group
+  input:-webkit-autofill,
+body[data-theme="dark"]
+  .cta-form-box
+  .input-group
+  input:-webkit-autofill:hover,
+body[data-theme="dark"]
+  .cta-form-box
+  .input-group
+  input:-webkit-autofill:focus {
   -webkit-text-fill-color: #ffffff !important;
   -webkit-box-shadow: 0 0 0px 1000px transparent inset !important;
   transition: background-color 5000s ease-in-out 0s !important;
 }
 
-/* Features Section */
-.features {
+/* Features section (general) */
+body[data-theme="dark"] .features {
   background: var(--bg);
 }
-
-.section-title,
-.features .section-title {
+body[data-theme="dark"]
+  .features
+  .section-title,
+body[data-theme="dark"]
+  .section-title {
   color: #ff6347 !important;
 }
-
-.h1 {
+body[data-theme="dark"] h1 {
   color: #ffffff !important;
 }
 
-.feature-box {
+/* Feature boxes: Fast Delivery / Affordable Rates / etc. */
+body[data-theme="dark"] .feature-box {
   background: #1a1a1a;
   border-color: #333;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
 }
-
-.feature-box h3 {
+body[data-theme="dark"] .feature-box h3 {
   color: #ffffff !important;
 }
-
-.feature-box p {
+body[data-theme="dark"] .feature-box p {
   color: #e0e0e0 !important;
 }
 
-/* Hero Action Buttons - ensure visibility and contrast in dark mode */
-.hero-actions .cta-btn.primary {
+/* Hero action buttons */
+body[data-theme="dark"] .hero-actions .cta-btn.primary {
   color: #fff !important;
   background: linear-gradient(135deg, #ff6b3d, #ff4500) !important;
   box-shadow: 0 10px 30px rgba(255, 107, 61, 0.35) !important;
   border: 2px solid transparent !important;
 }
-
-.hero-actions .cta-btn.primary:hover {
+body[data-theme="dark"] .hero-actions .cta-btn.primary:hover {
   background: linear-gradient(135deg, #ff7f5c, #ff6347) !important;
   box-shadow: 0 15px 40px rgba(255, 107, 61, 0.5) !important;
   border-color: rgba(255, 255, 255, 0.2) !important;
 }
-
-.hero-actions .cta-btn.secondary {
+body[data-theme="dark"] .hero-actions .cta-btn.secondary {
   background: rgba(224, 84, 84, 0.15) !important;
   color: #ffffff !important;
   border: 2px solid rgba(255, 255, 255, 0.3) !important;
   backdrop-filter: blur(10px);
 }
-
-.hero-actions .cta-btn.secondary:hover {
+body[data-theme="dark"] .hero-actions .cta-btn.secondary:hover {
   background: rgba(255, 255, 255, 0.25) !important;
   border-color: rgba(255, 255, 255, 0.5) !important;
 }
-
-.hero-actions .cta-btn.outline {
+body[data-theme="dark"] .hero-actions .cta-btn.outline {
   color: #ffffff !important;
   border-color: #ff6b3d !important;
   border-width: 2px !important;
   background: transparent !important;
 }
-
-.hero-actions .cta-btn.outline:hover {
+body[data-theme="dark"] .hero-actions .cta-btn.outline:hover {
   background: rgba(255, 107, 61, 0.15) !important;
   border-color: #ff7f5c !important;
   color: #ffffff !important;
 }
 
-/* Quote Card - Dark Theme */
+/* Quote card (Get Instant Quote) */
 body[data-theme="dark"] .quote-card {
   background: linear-gradient(145deg, rgba(30, 30, 30, 0.95), rgba(20, 20, 20, 0.95)) !important;
   border-color: rgba(255, 99, 71, 0.3) !important;
-  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.5), 0 0 30px rgba(255, 99, 71, 0.15) !important;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.5),
+    0 0 30px rgba(255, 99, 71, 0.15) !important;
 }
-
 body[data-theme="dark"] .quote-card:hover {
-  box-shadow: 0 25px 50px rgba(0, 0, 0, 0.6), 0 0 40px rgba(255, 99, 71, 0.25) !important;
+  box-shadow: 0 25px 50px rgba(0, 0, 0, 0.6),
+    0 0 40px rgba(255, 99, 71, 0.25) !important;
 }
-
 body[data-theme="dark"] .quote-header h3 {
   color: #ffffff !important;
 }
-
 body[data-theme="dark"] .quote-header p {
   color: #ff6b35 !important;
 }
 
-/* Step Progress - Dark Theme */
+/* Step progress */
 body[data-theme="dark"] .step-progress {
   background: rgba(255, 255, 255, 0.03) !important;
   border-color: rgba(255, 255, 255, 0.08) !important;
 }
-
 body[data-theme="dark"] .step-number {
   background: rgba(255, 255, 255, 0.08) !important;
   border-color: rgba(255, 255, 255, 0.2) !important;
   color: rgba(255, 255, 255, 0.4) !important;
 }
-
 body[data-theme="dark"] .step-label {
   color: rgba(255, 255, 255, 0.5) !important;
 }
-
 body[data-theme="dark"] .step.active .step-label {
   color: #ff6b35 !important;
 }
-
 body[data-theme="dark"] .step-line {
   background: rgba(255, 255, 255, 0.15) !important;
 }
 
-/* Form Fields - Dark Theme */
-body[data-theme="dark"] .form-group.floating-label input,
-body[data-theme="dark"] .form-group.floating-label select {
+/* Form fields (floating) */
+body[data-theme="dark"]
+  .form-group.floating-label
+  input,
+body[data-theme="dark"]
+  .form-group.floating-label
+  select {
   background: rgba(255, 255, 255, 0.05) !important;
   border-color: rgba(255, 255, 255, 0.1) !important;
   color: #ffffff !important;
 }
-
-body[data-theme="dark"] .form-group.floating-label label {
+body[data-theme="dark"]
+  .form-group.floating-label
+  label {
   color: rgba(255, 255, 255, 0.5) !important;
 }
-
-body[data-theme="dark"] .form-group.floating-label input:focus,
-body[data-theme="dark"] .form-group.floating-label input:not(:placeholder-shown),
-body[data-theme="dark"] .form-group.floating-label select:focus,
-body[data-theme="dark"] .form-group.floating-label select:not([value=""]) {
+body[data-theme="dark"]
+  .form-group.floating-label
+  input:focus,
+body[data-theme="dark"]
+  .form-group.floating-label
+  input:not(:placeholder-shown),
+body[data-theme="dark"]
+  .form-group.floating-label
+  select:focus,
+body[data-theme="dark"]
+  .form-group.floating-label
+  select:not([value=""]) {
   background: rgba(255, 99, 71, 0.1) !important;
   border-color: #ff6b35 !important;
 }
-
-body[data-theme="dark"] .form-group.floating-label input:focus ~ label,
-body[data-theme="dark"] .form-group.floating-label input:not(:placeholder-shown) ~ label,
-body[data-theme="dark"] .form-group.floating-label select:focus ~ label,
-body[data-theme="dark"] .form-group.floating-label select:not([value=""]) ~ label {
+body[data-theme="dark"]
+  .form-group.floating-label
+  input:focus
+  ~ label,
+body[data-theme="dark"]
+  .form-group.floating-label
+  input:not(:placeholder-shown)
+  ~ label,
+body[data-theme="dark"]
+  .form-group.floating-label
+  select:focus
+  ~ label,
+body[data-theme="dark"]
+  .form-group.floating-label
+  select:not([value=""])
+  ~ label {
   color: #ff6b35 !important;
 }
-
-body[data-theme="dark"] .form-group.floating-label select {
+body[data-theme="dark"]
+  .form-group.floating-label
+  select {
   background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6 9 12 15 18 9'%3e%3c/polyline%3e%3c/svg%3e") !important;
 }
-
-body[data-theme="dark"] .form-group.floating-label select option {
+body[data-theme="dark"]
+  .form-group.floating-label
+  select
+  option {
   background: #1a1a1a !important;
   color: white !important;
 }
 
-/* Autocomplete Dropdown - Dark Theme */
+/* Autocomplete dropdown */
 body[data-theme="dark"] .autocomplete-dropdown {
   background: #1a1a1a !important;
   border-color: #ff6b35 !important;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.7) !important;
 }
-
 body[data-theme="dark"] .autocomplete-item {
   color: white !important;
 }
-
-body[data-theme="dark"] .autocomplete-item:hover,
-body[data-theme="dark"] .autocomplete-item.active {
+body[data-theme="dark"]
+  .autocomplete-item:hover,
+body[data-theme="dark"]
+  .autocomplete-item.active {
   background: rgba(255, 99, 71, 0.2) !important;
   color: #ff6b35 !important;
 }
 
-/* Distance Display - Dark Theme */
+/* Distance display */
 body[data-theme="dark"] .distance-display {
   background: rgba(34, 197, 94, 0.1) !important;
   border-color: rgba(34, 197, 94, 0.3) !important;
   color: #22c55e !important;
 }
-
-body[data-theme="dark"] .distance-display strong {
+body[data-theme="dark"]
+  .distance-display
+  strong {
   color: #4ade80 !important;
 }
 
-/* Result Display - Dark Theme */
+/* Quote result */
 body[data-theme="dark"] .result-details {
   background: rgba(255, 255, 255, 0.05) !important;
 }
-
 body[data-theme="dark"] .result-row {
   border-bottom-color: rgba(255, 255, 255, 0.1) !important;
 }
-
 body[data-theme="dark"] .result-label {
   color: rgba(255, 255, 255, 0.7) !important;
 }
-
 body[data-theme="dark"] .result-value {
   color: #ffffff !important;
 }
-
 body[data-theme="dark"] .result-price {
   background: linear-gradient(135deg, rgba(255, 107, 53, 0.2) 0%, rgba(255, 69, 0, 0.2) 100%) !important;
   border-color: #ff6b35 !important;
 }
-
 body[data-theme="dark"] .result-price .label {
   color: rgba(255, 255, 255, 0.7) !important;
 }
-
 body[data-theme="dark"] .result-price .amount {
   color: #ff6b35 !important;
 }
 
-/* Back Button - Dark Theme */
+/* Quote buttons */
 body[data-theme="dark"] .quote-form-back-btn {
   background: rgba(255, 255, 255, 0.1) !important;
   color: #ffffff !important;
   border: 2px solid rgba(255, 255, 255, 0.2) !important;
 }
-
 body[data-theme="dark"] .quote-form-back-btn:hover {
   background: rgba(255, 255, 255, 0.15) !important;
   border-color: rgba(255, 255, 255, 0.3) !important;
 }
-
-/* Calculate Price Button - Dark Theme */
 body[data-theme="dark"] .quote-next,
 body[data-theme="dark"] .quote-form-submit-btn {
   background: linear-gradient(135deg, #ff6b35 0%, #ff4500 100%) !important;
@@ -387,157 +410,149 @@ body[data-theme="dark"] .quote-form-submit-btn {
   border: none !important;
   box-shadow: 0 4px 15px rgba(255, 99, 71, 0.3) !important;
 }
-
 body[data-theme="dark"] .quote-next:hover,
 body[data-theme="dark"] .quote-form-submit-btn:hover {
   background: linear-gradient(135deg, #ff7f5c 0%, #ff6347 100%) !important;
   box-shadow: 0 6px 25px rgba(255, 99, 71, 0.5) !important;
 }
 
-/* Completed Step - Dark Theme - Green Border Visible */
+/* Completed steps */
 body[data-theme="dark"] .step.completed .step-number {
   background: linear-gradient(135deg, #22c55e 0%, #16a34a 100%) !important;
   border-color: #22c55e !important;
   color: white !important;
-  box-shadow: 0 0 20px rgba(34, 197, 94, 0.6), 0 4px 15px rgba(34, 197, 94, 0.4) !important;
+  box-shadow: 0 0 20px rgba(34, 197, 94, 0.6),
+    0 4px 15px rgba(34, 197, 94, 0.4) !important;
 }
-
 body[data-theme="dark"] .step.completed .step-label {
   color: #22c55e !important;
   font-weight: 700 !important;
 }
 
-/* Delivery Time Display - Dark Theme */
+/* Delivery time */
 body[data-theme="dark"] .delivery-time-display {
   background: linear-gradient(135deg, rgba(59, 130, 246, 0.15) 0%, rgba(37, 99, 235, 0.15) 100%) !important;
   border-color: rgba(59, 130, 246, 0.3) !important;
 }
-
 body[data-theme="dark"] .delivery-time-display i {
   color: #60a5fa !important;
 }
-
 body[data-theme="dark"] .delivery-time-display .time-label {
   color: rgba(255, 255, 255, 0.7) !important;
 }
-
 body[data-theme="dark"] .delivery-time-display .time-value {
   color: #60a5fa !important;
 }
 
-/* Compare Prices Section - Dark Theme */
+/* Compare prices section (inside quote) */
 body[data-theme="dark"] .compare-prices-section {
   background: rgba(255, 255, 255, 0.03) !important;
   border-color: rgba(255, 255, 255, 0.1) !important;
 }
-
 body[data-theme="dark"] .compare-prices-header h4 {
   color: #ffffff !important;
 }
-
 body[data-theme="dark"] .compare-prices-header i {
   color: #fbbf24 !important;
 }
-
 body[data-theme="dark"] .price-option {
   background: rgba(255, 255, 255, 0.05) !important;
   border-color: rgba(255, 255, 255, 0.1) !important;
 }
-
 body[data-theme="dark"] .price-option:hover {
   background: rgba(255, 107, 53, 0.1) !important;
   border-color: #ff6b35 !important;
 }
-
 body[data-theme="dark"] .price-option.selected {
   background: rgba(34, 197, 94, 0.15) !important;
   border-color: #22c55e !important;
 }
-
 body[data-theme="dark"] .price-option.best-value {
   border-color: #fbbf24 !important;
 }
-
 body[data-theme="dark"] .price-option-name {
   color: #ffffff !important;
 }
-
 body[data-theme="dark"] .price-option-details {
   color: rgba(255, 255, 255, 0.6) !important;
 }
-
 body[data-theme="dark"] .price-option-amount {
   color: #ff6b35 !important;
 }
 
-/* Result Actions Buttons - Dark Theme */
+/* Quote result action buttons */
 body[data-theme="dark"] .quote-result-book-btn {
   background: linear-gradient(135deg, #22c55e 0%, #16a34a 100%) !important;
   color: #ffffff !important;
 }
-
 body[data-theme="dark"] .quote-save-later-btn {
   background: linear-gradient(135deg, #8b5cf6 0%, #7c3aed 100%) !important;
   color: #ffffff !important;
 }
-
 body[data-theme="dark"] .quote-result-reset-btn {
   background: rgba(255, 255, 255, 0.1) !important;
   color: #ffffff !important;
   border: 2px solid rgba(255, 255, 255, 0.2) !important;
 }
-
 body[data-theme="dark"] .quote-result-reset-btn:hover {
   background: rgba(255, 255, 255, 0.15) !important;
   border-color: rgba(255, 255, 255, 0.3) !important;
 }
 
-/* ---------------------------------------------------------
-   FIX: Service Cards Text & Background in Dark Mode
-   --------------------------------------------------------- */
-   body[data-theme="dark"] .service-card,
-   body[data-theme="dark"] .feature-card,
-   body[data-theme="dark"] .transport-card {
-       background: #ffffff !important;        /* keep white cards */
-       color: #1a1a1a !important;             /* dark text so readable */
-   }
-   
-   /* Card Title */
-   body[data-theme="dark"] .service-card h3,
-   body[data-theme="dark"] .feature-card h3,
-   body[data-theme="dark"] .transport-card h3 {
-       color: #ff6b3d !important;             /* your original orange */
-   }
-   
-   /* Card Paragraphs */
-   body[data-theme="dark"] .service-card p,
-   body[data-theme="dark"] .feature-card p,
-   body[data-theme="dark"] .transport-card p {
-       color: #333333 !important;             /* readable dark grey */
-   }
-   
-   /* Icons inside cards */
-   body[data-theme="dark"] .service-card i,
-   body[data-theme="dark"] .feature-card i,
-   body[data-theme="dark"] .transport-card i {
-       color: #ff6b3d !important;
-   }
-/* === Search bar visibility fix (global) === */
-.search-bar {
-  background: #3b3b3b !important;           /* lighter than navbar */
-  border: 1px solid #ff6a3d !important;     /* orange outline */
-  border-radius: 999px !important;          /* pill shape */
+/* Service / feature cards that intentionally stay white */
+body[data-theme="dark"] .service-card,
+body[data-theme="dark"] .feature-card,
+body[data-theme="dark"] .transport-card {
+  background: #ffffff !important;
+  color: #1a1a1a !important;
+}
+body[data-theme="dark"] .service-card h3,
+body[data-theme="dark"] .feature-card h3,
+body[data-theme="dark"] .transport-card h3 {
+  color: #ff6b3d !important;
+}
+body[data-theme="dark"] .service-card p,
+body[data-theme="dark"] .feature-card p,
+body[data-theme="dark"] .transport-card p {
+  color: #333333 !important;
+}
+body[data-theme="dark"] .service-card i,
+body[data-theme="dark"] .feature-card i,
+body[data-theme="dark"] .transport-card i {
+  color: #ff6b3d !important;
+}
+
+/* Search bar (global visibility fix) */
+body[data-theme="dark"] .search-bar {
+  background: #3b3b3b !important;
+  border: 1px solid #ff6a3d !important;
+  border-radius: 999px !important;
   padding: 8px 16px !important;
 }
-
-.search-bar input {
-  color: #ffffff !important;                /* visible text */
+body[data-theme="dark"] .search-bar input {
+  color: #ffffff !important;
   font-size: 0.9rem !important;
 }
-
-.search-bar input::placeholder {
-  color: #f0f0f0 !important;                /* light placeholder */
+body[data-theme="dark"] .search-bar input::placeholder {
+  color: #f0f0f0 !important;
   opacity: 0.9 !important;
 }
 
+/* Pricing CTA: "Compare Our Pricing Plans" */
+body[data-theme="dark"] .pricing-cta-section {
+  background: linear-gradient(145deg, #1a1a1a, #0f1115);
+  border-top: 1px solid #333;
+  border-bottom: 1px solid #333;
+}
+body[data-theme="dark"] .pricing-cta-section h3 {
+  color: #ffffff;
+}
+body[data-theme="dark"] .pricing-cta-section p {
+  color: #d1d1d1;
+}
 
+/* Footer container hook */
+body[data-theme="dark"] #footer-container {
+  background-color: var(--footer-bg) !important;
+  color: var(--footer-text);
+}


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #702 

## Rationale for this change

Dark mode currently has several readability and consistency issues on the home page. Text in the feature section and pricing CTA becomes low-contrast or nearly invisible, and some surfaces keep light backgrounds while the rest of the page switches to dark. This PR updates the dark‑mode styles so that all key content remains legible and visually consistent with the rest of the theme.

## What changes are included in this PR?

- Refactors dark-mode.css to fix invalid selector nesting and ensure all dark‑mode rules are applied correctly.
- Adds dark‑mode styles for the home feature boxes (e.g. “Fast Delivery”, “Affordable Rates”) so headings and body text use high‑contrast colors on a dark background.
- Adds a dark‑mode background and text colors for the “Compare Our Pricing Plans” CTA section to match the overall dark theme.
- Keeps existing card components that are intentionally light (service/feature/transport cards) readable by explicitly setting dark text on white backgrounds.
- Aligns search bar styling in dark mode with the navbar so input text and placeholder remain visible.


## Are these changes tested?

- Manually tested the home page in both light and dark mode on desktop (Chrome) to verify:
  - Feature boxes have readable headings and descriptions.
  - Pricing CTA section background and text match the dark theme and maintain contrast.
  - Quote widget, search bar, and contact CTA still behave correctly and look consistent.
- Verified there are no visual regressions in light mode for the touched components.

## Are there any user-facing changes?

Yes, dark‑mode users will see improved readability and a more consistent dark theme on the home page, especially in the hero feature area, pricing CTA, and search bar.

No breaking changes to public APIs; changes are limited to CSS and visual styling.

## Screenshots (if Applicable)
<img width="1920" height="849" alt="image" src="https://github.com/user-attachments/assets/d2ece069-5e4e-44c0-b1c8-06e1c1d1a816" />

<img width="1920" height="844" alt="image" src="https://github.com/user-attachments/assets/937a41cb-7171-4c1f-9e97-3796c08be0d2" />

<img width="1919" height="838" alt="image" src="https://github.com/user-attachments/assets/5176bb75-0bd7-420e-b845-12796d5fa41d" />
