### PR TITLE
Fix: Improve text visibility in Basic Information section for light mode

### DIFF
--- a/frontend/css/pages/enquiry.css
+++ b/frontend/css/pages/enquiry.css
@@ -64,3 +64,60 @@
       padding: 0;
     }
  
+
+    /* Light Mode - Make form sections match the white card theme */
+body:not(.dark-mode) .form-step {
+    background: #ffffff !important;
+    border-radius: 12px;
+    padding: 30px;
+}
+
+/* Light Mode - Labels and text styling */
+body:not(.dark-mode) .form-step label {
+    color: #2b2b2b !important;
+    font-weight: 500;
+}
+
+body:not(.dark-mode) .form-step .step-header h3 {
+    color: #1a1a1a !important;
+}
+
+body:not(.dark-mode) .form-step .step-header p {
+    color: #666666 !important;
+}
+
+/* Helper text visibility */
+body:not(.dark-mode) .phone-format-hint,
+body:not(.dark-mode) .email-suggestion,
+body:not(.dark-mode) .char-counter,
+body:not(.dark-mode) .date-warning {
+    color: #888888 !important;
+}
+
+/* Icons color for light mode */
+body:not(.dark-mode) .form-step label i {
+    color: #ff6347 !important;
+}
+
+/* Input fields styling for light mode */
+body:not(.dark-mode) .form-step input,
+body:not(.dark-mode) .form-step textarea,
+body:not(.dark-mode) .form-step select {
+    background: #f9f9f9 !important;
+    color: #2b2b2b !important;
+    border: 1px solid #e0e0e0 !important;
+}
+
+body:not(.dark-mode) .form-step input::placeholder,
+body:not(.dark-mode) .form-step textarea::placeholder {
+    color: #aaaaaa !important;
+}
+
+/* Progress bar and buttons for light mode */
+body:not(.dark-mode) .form-progress {
+    background: #f5f5f5 !important;
+}
+
+body:not(.dark-mode) .progress-text {
+    color: #2b2b2b !important;
+}


### PR DESCRIPTION
This PR addresses the text visibility issue in the enquiry form's Basic Information section when using light mode. Previously, labels, helper text, and other text elements were not visible due to insufficient color contrast.


Changes Made

- Applied white card background to form sections in light mode for clean UI
- Fixed label text visibility (Full Name, Phone Number, Email Address)
- Improved helper text contrast (Format: 9372693389)
- Styled section subtitle ("Tell us about yourself") with proper color
- Updated input fields with light gray background and dark text
- Maintained orange/red icon colors for visual consistency
- Added proper placeholder text styling
- Preserved dark mode functionality without breaking existing styles

<img width="1900" height="841" alt="image" src="https://github.com/user-attachments/assets/c6d2d3b0-43de-447e-b949-1d1edba1b0da" />


Closes #746 