### PR TITLE
[ENHANCEMENT] Add CSS-Only Safe Tap Zones for Mobile Users #642

### DIFF
--- a/css/components/safe-tap-zones.css
+++ b/css/components/safe-tap-zones.css
@@ -1,0 +1,42 @@
+/* ===================================================================
+   [ENHANCEMENT] CSS-Only Safe Tap Zones for Mobile Users
+   Description:
+   Improves touch accuracy for buttons, links, and CTAs on mobile
+   devices (coarse pointers) without changing visual layout.
+   =================================================================== */
+
+@media (pointer: coarse) {
+
+  /* Target all interactive elements */
+  button,
+  a,
+  .cta-btn {
+    position: relative; /* Required for ::before absolute positioning */
+    min-width: 44px;    /* Ensure minimum touch width */
+    min-height: 44px;   /* Ensure minimum touch height */
+  }
+
+  /* Invisible tap buffer using ::before pseudo-element */
+  button::before,
+  a::before,
+  .cta-btn::before {
+    content: "";
+    position: absolute;
+    top: -8px;
+    left: -8px;
+    right: -8px;
+    bottom: -8px;
+    pointer-events: auto; /* Make expanded area tappable */
+    background: transparent;
+    z-index: 1; /* Ensure it sits above the element for touch, but invisible */
+  }
+
+  /* Optional: visual debug mode - remove in production */
+  /* 
+  button::before,
+  a::before,
+  .cta-btn::before {
+    border: 1px dashed red;
+  } 
+  */
+}


### PR DESCRIPTION
## Description
This enhancement introduces a CSS-only Safe Tap Zone system to improve touch accuracy and usability for mobile users on coarse pointer devices (touchscreens).

The system expands the effective tappable area of interactive elements (buttons, links, CTAs) without changing their visual layout, ensuring better accessibility and reducing mis-taps on smaller screens.

## Problem It Solves
- Small buttons and links on mobile are often hard to tap accurately.
- Users frequently trigger wrong actions.
- Existing fixes are usually JS-based or layout-changing.

This solution addresses the issue purely via CSS:
- Lightweight and non-intrusive
- Easy to maintain
- Improves accessibility

## How It Works
- Adds an invisible tap buffer using `::before`.
- Enforces a minimum touch target size (44×44px) per accessibility guidelines.
- Works only on touch devices using `@media (pointer: coarse)`.
- Keeps existing UI design intact.

## Impact
- Better mobile UX
- Fewer accidental taps
- Zero performance overhead

## Notes
- This is a CSS-only enhancement.
- No changes to themes or animations.
