### PR TITLE
Fix duplicate theme toggle and ensure mobile visibility

### DIFF
--- a/frontend/components/navbar.html
+++ b/frontend/components/navbar.html
@@ -319,15 +319,8 @@
               <i class="fas fa-question-circle"></i>
             </a>
           </div>
-
-          <!-- Theme Toggle: placed after Enquiry and before Login -->
-          <div class="nav-theme-toggle">
-            <button id="theme-toggle" aria-label="Toggle theme" class="nav-theme-btn">
-              <i id="theme-icon" class="fas fa-sun"></i>
-            </button>
-          </div>
         </div>
-
+        
         <!-- <div class="nav-actions">
           <a href="../pages/login.html" class="login-btn" data-tooltip="Login">
             <i class="fas fa-user"></i>
@@ -365,9 +358,15 @@
         <span class="menu-bar"></span>
         <span class="menu-bar"></span>
       </button>
-
+      
+      <!-- Theme Toggle: placed after Enquiry and before Login -->
+      <div class="nav-theme-toggle">
+        <button id="theme-toggle" aria-label="Toggle theme" class="nav-theme-btn">
+          <i id="theme-icon" class="fas fa-sun"></i>
+        </button>
+      </div>
       <!-- Mobile Theme Toggle (visible on small screens) -->
-      <button id="mobile-theme-toggle" aria-label="Toggle theme" class="nav-theme-btn mobile-theme-btn" data-tooltip="Toggle theme">
+      <!--button id="mobile-theme-toggle" aria-label="Toggle theme" class="nav-theme-btn mobile-theme-btn" data-tooltip="Toggle theme">
         <i id="mobile-theme-icon" class="fas fa-sun"></i>
       </button>
     </div>

--- a/frontend/css/components/navbar.css
+++ b/frontend/css/components/navbar.css
@@ -976,16 +976,20 @@ left: 100%;
   }
   
   .nav-right-section {
-    display: none !important;
+    display: flex !important;
+    align-items: center;
   }
   
   
   .nav-theme-toggle {
-    display: none !important;
+    display: flex !important;
+    align-items: center;
+    justify-content:center;
+    margin-left: 8px;
   }
 
   .mobile-theme-btn {
-    display: flex !important;
+    display: none !important;
     align-items: center;
     justify-content: center;
     width: 36px;


### PR DESCRIPTION
This PR fixes the duplicate theme toggle issue by using a single toggle and ensuring it is visible on both desktop and mobile views.

Fixes #797
## Before View 
<img width="1299" height="113" alt="Screenshot 2026-01-11 at 5 22 24 PM" src="https://github.com/user-attachments/assets/1c7e5051-334f-4ca8-901a-21f8c70dd379" />

## Desktop View
<img width="1440" height="198" alt="Screenshot 2026-01-11 at 5 19 40 PM" src="https://github.com/user-attachments/assets/912390e6-b943-44c1-b46e-1e38be0fd82b" />

## Mobile View
<img width="352" height="516" alt="Screenshot 2026-01-11 at 5 20 16 PM" src="https://github.com/user-attachments/assets/f7ba1ce5-2b0e-4479-b175-7fe7d2e50a28" />
