### PR TITLE
fix: enhance FAQ layout for mobile responsiveness and refactor styles

### DIFF
--- a/frontend/css/pages/faq.css
+++ b/frontend/css/pages/faq.css
@@ -365,30 +365,3 @@
             border-color: #ff6347 !important;
             color: white !important;
         }
-
-    @media (max-width: 768px) {
-    .faq-item {
-        width: 100%;
-        min-width: 100%;
-    }
-
-    .faq-section {
-        padding: 50px 0;
-    }
-
-    .faq-categories {
-        justify-content: flex-start;
-        flex-wrap: nowrap;
-        overflow-x: auto;
-        padding-bottom: 10px;
-        -webkit-overflow-scrolling: touch; /* Smooth scroll on iOS */
-    }
-
-    .faq-category-btn {
-        flex: 0 0 auto; 
-    }
-
-    .section-title h2 {
-        font-size: 1.8rem;
-    }
-}

--- a/frontend/css/responsive/360px-500px.css
+++ b/frontend/css/responsive/360px-500px.css
@@ -1425,3 +1425,32 @@
     pointer-events: none !important;
   }
 }
+
+
+/*faq.css*/
+@media (max-width: 768px) {
+    .faq-item {
+        width: 100%;
+        min-width: 100%;
+    }
+
+    .faq-section {
+        padding: 50px 0;
+    }
+
+    .faq-categories {
+        justify-content: flex-start;
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        padding-bottom: 10px;
+        -webkit-overflow-scrolling: touch; /* Smooth scroll on iOS */
+    }
+
+    .faq-category-btn {
+        flex: 0 0 auto; 
+    }
+
+    .section-title h2 {
+        font-size: 1.8rem;
+    }
+}

--- a/frontend/pages/faq.html
+++ b/frontend/pages/faq.html
@@ -24,6 +24,7 @@
     <link rel="stylesheet" href="../css/components/animations.css">
     <link rel="stylesheet" href="../css/components/glowing-input.css">
     <link rel="stylesheet" href="../css/pages/faq.css">
+    <link rel="stylesheet" href="../css/responsive/360px-500px.css"
 
     
 </head>


### PR DESCRIPTION
**What I changed:**
- Made the FAQ look better on phones: I fixed the layout of buttons and text in faq items from shrinking.
- Fixed the Category buttons: I made the category buttons scroll sideways (left to right) on mobile. This saves a lot of space so users don't have to scroll past a long list of buttons.
- Cleaned up spacing: I reduced the large empty spaces at the top and bottom of the page on mobile so the content is easier to see.

**How to test:**
1. Open the FAQ page on a mobile phone or resize your browser.
2. Check that the questions now take up the full width of the screen.
3.Swipe the category buttons left and right to see the new scrolling feature.

**Visual proof:** I have attached a "Before and After" video to show how much easier the page is to use now.
[iPhone-13-PRO-127.0.0.1--z1pin6hvtbl6z.webm](https://github.com/user-attachments/assets/d197f1a3-fd45-4464-a312-69aead8a0b75)
[iPhone-13-PRO-127.0.0.1-0hslstldyph195.webm](https://github.com/user-attachments/assets/1f23ba84-9810-490c-bbe9-5d2e1e0b94f0)

