### PR TITLE
Change in percentage value in performance metrics

### DIFF
--- a/frontend/js/modules/about-animations.js
+++ b/frontend/js/modules/about-animations.js
@@ -347,6 +347,20 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 });
 
+// Sync performance metric percentage text with progress bar value
+document.addEventListener("DOMContentLoaded", () => {
+  document.querySelectorAll(".infographic-item").forEach(item => {
+    const bar = item.querySelector(".infographic-bar-fill");
+    const label = item.querySelector(".infographic-label .percentage-value");
+
+    let percentage = bar.dataset.percentage || 0;
+    percentage = Math.min(100, Math.max(0, percentage));
+
+    bar.style.setProperty("--bar-width", percentage+"%");
+    label.textContent = percentage+"%";
+  });
+});
+
 // Export for module usage
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = { AboutPageAnimations, AboutAnimationUtils };

--- a/frontend/pages/about.html
+++ b/frontend/pages/about.html
@@ -604,7 +604,6 @@
             </div>
             <div class="infographic-bar">
               <div class="infographic-bar-fill" data-percentage="96">
-                <span class="percentage-value">96%</span>
               </div>
             </div>
           </div>
@@ -616,7 +615,6 @@
             </div>
             <div class="infographic-bar">
               <div class="infographic-bar-fill" data-percentage="92">
-                <span class="percentage-value">92%</span>
               </div>
             </div>
           </div>
@@ -628,7 +626,6 @@
             </div>
             <div class="infographic-bar">
               <div class="infographic-bar-fill" data-percentage="99">
-                <span class="percentage-value">99%</span>
               </div>
             </div>
           </div>
@@ -640,7 +637,6 @@
             </div>
             <div class="infographic-bar">
               <div class="infographic-bar-fill" data-percentage="85">
-                <span class="percentage-value">85%</span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
**Description:**
On the Performance Metrics section, the numerical percentage displayed on the right side of each metric shows 0%, even though the progress bar clearly reflects a valid non-zero percentage (e.g., 96%, 92%, 99%, 85%).

This creates a UI inconsistency where the visual indicator and the textual value do not match.

**Changes Made:**

- Synced progress bar size with data-percentage values

- Dynamically updated percentage text using JavaScript

- Removed dependency on hardcoded percentage values in HTML which helps in reducing confusion and building cleaner HTML

- Ensured values remain within valid range (0–100)

- Improved reliability of animation on page load

**Checklist**

 Code follows project style guidelines

 Tested on desktop browser

 No console errors

 Fix verified visually

**Before Fixes:**
<img width="1414" height="793" alt="image" src="https://github.com/user-attachments/assets/849c16f3-8d24-4f6f-af79-637c6eddbb0d" />

**After Fixing:**

https://github.com/user-attachments/assets/52eb8c02-c5fe-47b9-8032-0307c083ef6d


Fixes #896 