### PR TITLE
fix: Fixed text content not visible on terms page in dark mode

### DIFF
--- a/frontend/css/pages/TermsAndService.css
+++ b/frontend/css/pages/TermsAndService.css
@@ -34,7 +34,7 @@ header {
 }
 
 h2 {
-  color: #0a3d62;
+  color: #075b97;
   margin-bottom: 0.5rem;
 }
 
@@ -87,4 +87,9 @@ footer a:hover {
 .fade-in.show {
   opacity: 1;
   transform: translateY(0);
+}
+
+/* Dark Mode Support */
+body[data-theme="dark"] .container {
+  background-color: #333;
 }


### PR DESCRIPTION
### Description
Fixed text content not visible on terms page in dark mode.

### Screenshot
<img width="1901" height="1021" alt="Screenshot 2026-01-29 223059" src="https://github.com/user-attachments/assets/900f0595-2dcc-4b12-a5f9-0f4cab460abb" />

### Fix
closes #923 