### PR TITLE
Fix: enable Next button immediately on dropdown selection

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -629,6 +629,82 @@
   <script src="js/modules/loading-state-manager.js"></script>
   <script src="js/modules/page-navigation-loader.js"></script>
 
+  <script>
+  let cities = [];
+
+  const nextBtn = document.getElementById("step1Next");
+  nextBtn.disabled = true;
+
+  fetch("/frontend/assets/data/cities.json")
+    .then(res => res.json())
+    .then(data => {
+      cities = data.map(c =>
+        c.name.replace("Car Transport in ", "")
+      );
+
+      // Setup autocompletes after cities are loaded
+      setupAutocomplete("fromCity", "fromCityDropdown");
+      setupAutocomplete("toCity", "toCityDropdown");
+    });
+
+  function isValidCity(value) {
+    return cities.some(
+      city => city.toLowerCase() === value.toLowerCase()
+    );
+  }
+
+  function updateNextButton() {
+    const fromCity = document.getElementById("fromCity").value;
+    const toCity = document.getElementById("toCity").value;
+
+    nextBtn.disabled = !(isValidCity(fromCity) && isValidCity(toCity));
+  }
+
+  function setupAutocomplete(inputId, dropdownId) {
+    const input = document.getElementById(inputId);
+    const dropdown = document.getElementById(dropdownId);
+
+    input.addEventListener("input", () => {
+      const value = input.value.toLowerCase();
+      dropdown.innerHTML = "";
+
+      if (!value) {
+        updateNextButton();
+        return;
+      }
+
+      const matches = cities.filter(city =>
+        city.toLowerCase().startsWith(value)
+      );
+
+      matches.forEach(city => {
+        const div = document.createElement("div");
+        div.textContent = city;
+
+        div.addEventListener("mousedown", () => {
+          input.value = city;
+          dropdown.innerHTML = "";
+          updateNextButton(); 
+        });
+
+        dropdown.appendChild(div);
+      });
+
+      updateNextButton();
+    });
+
+    input.addEventListener("blur", () => {
+      if (input.value && !isValidCity(input.value)) {
+        input.value = "";
+        alert("Service not available in this city");
+      } else {
+        updateNextButton();
+      }
+    });
+  }
+</script>
+
+
   <!-- Enhanced Preloader Logic -->
   <script>
     (function() {


### PR DESCRIPTION
### Description:

The city input field accepts invalid or incorrect city names, even when those cities are not supported or recognized by the system. This allows users to proceed with incorrect data.

### Changed Made:

- Added strict validation to ensure the city input fields accept only supported and recognized city names.
- Prevented users from proceeding when an invalid or unsupported city is entered.
- Implemented case-insensitive validation so valid cities are correctly recognized regardless of input casing.
- Ensured the Next button is enabled only when both city inputs contain valid values, blocking incorrect data flow.

### Before Fix:
<img width="613" height="751" alt="image" src="https://github.com/user-attachments/assets/a35cfd2e-e5cb-4a4f-a7a5-49d42337afbf" />

### After fix:

https://github.com/user-attachments/assets/907d14e0-dbff-4f02-b84f-34a5cbeb24b2

Fixes #899 

Contributing as a contributor under SWoC'26