### PR TITLE
Fixed emergency reference number duplication using UUID

### DIFF
--- a/backend/controllers/emergencyRequest.controller.js
+++ b/backend/controllers/emergencyRequest.controller.js
@@ -1,9 +1,12 @@
 import EmergencyRequest from "../models/emergencyRequest.model.js";
 import { sendEmergencyEmail } from "../utils/sendEmail.js";
 
+import crypto from "crypto"; // For generating unique reference numbers
+
 const generateReferenceNumber = () => {
-  return `EMG${Date.now()}`;
+  return `EMG-${crypto.randomUUID()}`; // Fixed the function to generate a unique reference number using UUID
 };
+
 
 export const createEmergencyRequest = async (req, res) => {
   try {


### PR DESCRIPTION
Hi @Nikhilsingh 👋  
This PR fixes the emergency reference number duplication issue by using a collision-safe UUID-based approach.

## What was fixed
The issue was caused by timestamp-based reference number generation using `Date.now()`, which could produce duplicate emergency reference numbers when multiple requests were created within the same millisecond.

## What I changed
- Replaced `Date.now()` based reference generation with `crypto.randomUUID()`
- Ensured collision-safe, globally unique emergency reference numbers

## Modified File
backend/controllers/emergencyRequest.controller.js

## Type of Change
- [x] Bug fix (non-breaking change)

## Checklist
- [x] Linked the related issue
- [x] Followed repository guidelines
- [x] Performed self-review

Fixes #957
