### PR TITLE
fix: scope pricing-calculator CSS to prevent navbar search bar override (#1048)

### DIFF
--- a/frontend/css/components/pricing-calculator.css
+++ b/frontend/css/components/pricing-calculator.css
@@ -1104,15 +1104,18 @@ body[data-theme="dark"] .faq-item-accordion {
   border-color: #333;
 }
 
-/* Inputs */
-body[data-theme="dark"] input,
-body[data-theme="dark"] select {
+/* Inputs — scoped to calculator page sections to avoid overriding navbar search bar */
+body[data-theme="dark"] .price-calculator input,
+body[data-theme="dark"] .price-calculator select,
+body[data-theme="dark"] .plan-comparison input,
+body[data-theme="dark"] .plan-comparison select {
   background: #1f1f3a;
   color: #ffffff;
   border-color: #333;
 }
 
-body[data-theme="dark"] input::placeholder {
+body[data-theme="dark"] .price-calculator input::placeholder,
+body[data-theme="dark"] .plan-comparison input::placeholder {
   color: #aaa;
 }
 


### PR DESCRIPTION
## Fixes #1048

### Root Cause

`pricing-calculator.css` had an unscoped dark-mode input selector:

```css
/* Before (too broad — bleeds into navbar) */
input, select {
  background: #1f1f3a;
  color: #e2e8f0;
}
```

- Since pricing-calculator.css loads after navbar.css, same-specificity rules won via CSS cascade, overriding .search-bar input { background: transparent } and painting the navbar search bar dark navy.


### Fix
- Scoped the selectors to page-specific containers that only exist on the pricing calculator page: 


```css
/* After (scoped — navbar unaffected) */
.price-calculator input,
.price-calculator select,
.plan-comparison input,
.plan-comparison select {
  background: #1f1f3a;
  color: #e2e8f0;
}
```
---
Closes #1048

@gouravKJ @Nikhilrsingh please review!