### PR TITLE
fix: suppress dark hover bleed on blog hero filter buttons (#1050)

### DIFF
--- a/frontend/css/pages/blog.css
+++ b/frontend/css/pages/blog.css
@@ -239,6 +239,22 @@ body[data-theme="light"] .pill {
   box-shadow: 0 5px 15px rgba(255, 99, 71, 0.15);
 }
 
+/*
+ * Fix #1050: Global button::before dark gradient in styles.css becomes
+ * visible on hover because .pill:hover sets a near-transparent background.
+ * Suppress the pseudo-element and enforce an opaque white background
+ * specifically for pills inside the orange blog hero.
+ */
+.blog-hero .pill::before {
+  display: none !important;
+}
+
+.blog-hero .pill:hover {
+  background: white !important;
+  color: #e8521a !important;
+  border-color: white !important;
+}
+
 /* Active State */
 .pill.active {
   background: linear-gradient(135deg, #ff6347, #ff4500);


### PR DESCRIPTION
## Fixes #1050

### Root Cause

The actual cause differed from the issue guess. `styles.css` injects a global dark gradient `::before` pseudo-element on **every** `<button>`:

```css
/* styles.css:5073 — affects all buttons */
button::before {
  background: linear-gradient(#44413b, #aaa29b, #484843);
  opacity: 0;
}
button:hover::before {
  opacity: 1; /* dark gradient bleeds through */
}
```

-  .pill:hover sets background: rgba(255,99,71, 0.05) — only 5% opacity — so the dark ::before bled through, producing the black appearance.

### Fix
- Added two scoped rules in blog.css to suppress the dark pseudo-element only within .blog-hero:

```css
/* blog.css — scoped, zero impact on other pages */
.blog-hero .pill::before {
  display: none;
}
.blog-hero .pill:hover {
  background: white !important;
  color: #e8521a;
}
```
---
Closes #1050

@Nikhilrsingh @gouravKJ please review!

