### PR TITLE
Fix: Dropdown menu container width issue (Icons overflowing)

### DIFF
--- a/frontend/css/components/navbar.css
+++ b/frontend/css/components/navbar.css
@@ -765,7 +765,7 @@ body {
   top: calc(100% + 1rem);
   border-radius: 8px;
   padding: 1rem;
-  width: 200px;
+  width: 250px;
   color: white;
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.5);
   font-size: 0.9rem;


### PR DESCRIPTION
Closes #1066

In the **Services dropdown menu**, the container width was not properly accommodating all menu items.
As a result:

* Icons were partially overflowing outside the dropdown container.
* The layout looked misaligned and visually inconsistent.
* UI appeared broken in certain screen sizes.

### ✅ Solution

* Increased the width of the dropdown menu container.
* Ensured all icons and text are properly aligned within the container.
* Maintained consistent spacing and visual balance.

### 📸 Before
<img width="1920" height="1080" alt="Screenshot (246)" src="https://github.com/user-attachments/assets/89de6ecc-4a70-4d76-8a11-4d63c5706186" />


### 📸 After

<img width="1920" height="1080" alt="Screenshot (248)" src="https://github.com/user-attachments/assets/b51b5aae-d01e-4744-ac2f-8749d6c4b714" />



### 🧪 Testing

* Tested on different screen sizes (desktop and responsive view).
* Verified that all dropdown items render correctly.
* Confirmed no layout breakage in other navbar elements.