### PR TITLE
fix(invoice): derive customer state from booking data instead of hard…

### DIFF
--- a/backend/controllers/booking.controller.js
+++ b/backend/controllers/booking.controller.js
@@ -284,7 +284,11 @@ export const updateBookingStatus = async (req, res, next) => {
           });
 
           // Calculate GST (assume same state for demo - intra-state CGST+SGST)
-          invoice.calculateTaxBreakdown('Maharashtra', 'Maharashtra', 18);
+          invoice.calculateTaxBreakdown(
+               booking.customerState || 'Maharashtra',
+               'Maharashtra',
+               18
+             );
 
           await invoice.save();
           console.log(`✅ Invoice ${invoiceNumber} auto-generated for booking ${booking.bookingReference}`);


### PR DESCRIPTION
## PR Description

### 👨‍💻 Program
This contribution is made under **GSSoC 2026**.

---

### 📌 Summary
Fixes auto-generated invoice tax breakdown to derive the customer state from booking data instead of always hardcoding `'Maharashtra'`. Previously, all auto-generated invoices used `calculateTaxBreakdown('Maharashtra', 'Maharashtra', 18)` regardless of where the customer was actually located, producing incorrect GST splits (CGST+SGST instead of IGST) for every inter-state delivery.

---

### ❌ Problem

**File:** `backend/controllers/booking.controller.js` — line ~290

❌ `invoice.calculateTaxBreakdown('Maharashtra', 'Maharashtra', 18)` — customer state hardcoded  
❌ CGST + SGST applied to inter-state transactions instead of IGST  
❌ Manual invoice endpoint (`POST /api/invoices`) already handles `customerState` correctly — auto-generation path does not  
❌ Every inter-state invoice is legally incorrect under Indian GST law  

---

### ✅ Solution

Derive the customer state from `booking.customerState` and fall back to `'Maharashtra'` only when the field is absent, matching the logic already used in the manual invoice creation endpoint.

---

### 📝 Exact Line Change

**File:** `backend/controllers/booking.controller.js` — line ~287

```diff
- invoice.calculateTaxBreakdown('Maharashtra', 'Maharashtra', 18);
+ invoice.calculateTaxBreakdown(
+   booking.customerState || 'Maharashtra',
+   'Maharashtra',
+   18
+ );
```

---

### 🔄 Before vs After

#### Before: All auto-generated invoices use CGST+SGST → wrong GST type for inter-state deliveries
#### After: Customer state derived from booking → correct IGST for inter-state, CGST+SGST for intra-state

---

### 🧪 Testing

- Create a booking with `customerState: 'Karnataka'`, mark as `delivered` → invoice shows IGST ✅
- Create a booking with `customerState: 'Maharashtra'`, mark as `delivered` → invoice shows CGST+SGST ✅
- Create a booking with no `customerState`, mark as `delivered` → falls back to `'Maharashtra'`, no crash ✅

---

### 🙌 Contributor Checklist

- [x] Code follows repository guidelines
- [x] Tested thoroughly
- [x] No breaking changes introduced

---

# Closes #1281

---