### PR TITLE
fix(model): add missing email field to Booking schema so guest bookin…

### DIFF
--- a/backend/models/booking.model.js
+++ b/backend/models/booking.model.js
@@ -22,6 +22,14 @@ const bookingSchema = new mongoose.Schema({
     match: [/^[6-9]\d{9}$/, 'Please provide a valid 10-digit Indian phone number']
   },
 
+  email: {
+    type: String,
+    lowercase: true,
+    trim: true,
+    match: [/^\S+@\S+\.\S+$/, 'Invalid email format'],
+    default: ''
+  },
+
   // Vehicle Information
   vehicleType: {
     type: String,


### PR DESCRIPTION
## PR Description

### 👨‍💻 Program
This contribution is made under **GSSoC 2026**.

---

### 📌 Summary
Adds the missing `email` field to the `Booking` Mongoose schema. The field was indexed (`bookingSchema.index({ email: 1 })`), queried by `getBookingByEmail`, and read during invoice auto-generation (`booking.email`), but was never declared in the schema. Mongoose silently strips unknown fields on save, so every guest booking lost its email at write time and all email-based lookups returned `404`.

---

### ❌ Problem

**File:** `backend/models/booking.model.js` — after line 24 (phone field)

❌ `bookingSchema.index({ email: 1 })` — index declared but field is missing from schema  
❌ Mongoose silently strips `email` from every saved booking document  
❌ `GET /api/bookings/email/:email` always returns `404` — no document ever has the field  
❌ Auto-generated invoices always have blank `customer.email` (`booking.email` is always `undefined`)  

---

### ✅ Solution

Add the `email` field to the `bookingSchema` with validation matching the `User` model, placed after the `phone` field.

---

### 📝 Exact Line Change

**File:** `backend/models/booking.model.js` — after the `phone` field (~line 24)

```diff
  phone: {
    type: String,
    required: [true, 'Phone number is required'],
    trim: true,
    match: [/^[6-9]\d{9}$/, 'Please provide a valid 10-digit Indian phone number']
  },
+
+ email: {
+   type: String,
+   lowercase: true,
+   trim: true,
+   match: [/^\S+@\S+\.\S+$/, 'Invalid email format'],
+   default: ''
+ },
```

---

### 🔄 Before vs After

#### Before: `email` stripped on save → `GET /api/bookings/email/:email` always 404 → invoices have blank customer email
#### After: `email` persisted correctly → email lookup works → invoice `customer.email` populated

---

### 🧪 Testing

- `POST /api/bookings` with `email: "guest@example.com"` → email saved in MongoDB ✅
- `GET /api/bookings/email/guest@example.com` → returns matching bookings ✅
- Mark booking as `delivered` → auto-generated invoice has correct `customer.email` ✅
- `POST /api/bookings` without `email` → saves with `email: ""` default, no error ✅

---

### 🙌 Contributor Checklist

- [x] Code follows repository guidelines
- [x] Tested thoroughly
- [x] No breaking changes introduced

---

# Closes #1277

---