### PR TITLE
fix: align 404 car and road animation direction

### DIFF
--- a/frontend/404.html
+++ b/frontend/404.html
@@ -58,56 +58,51 @@
               </filter>
             </defs>
 
-            <!-- shadow -->
-            <ellipse cx="110" cy="76" rx="78" ry="10" fill="rgba(0,0,0,0.35)" />
+            <g transform="translate(220, 0) scale(-1, 1)">
+              <ellipse cx="110" cy="76" rx="78" ry="10" fill="rgba(0,0,0,0.35)" />
 
-            <!-- body -->
-            <path filter="url(#softGlow)" d="M25 58
-                     C28 42 42 34 62 34
-                     L90 34
-                     C98 23 112 17 130 17
-                     L150 17
-                     C165 17 176 23 186 34
-                     L198 34
-                     C209 34 216 40 216 52
-                     L216 62
-                     C216 68 212 72 206 72
-                     L22 72
-                     C15 72 12 67 13 61
-                     L25 58 Z" fill="url(#carBody)" />
+              <path filter="url(#softGlow)" d="M25 58
+                       C28 42 42 34 62 34
+                       L90 34
+                       C98 23 112 17 130 17
+                       L150 17
+                       C165 17 176 23 186 34
+                       L198 34
+                       C209 34 216 40 216 52
+                       L216 62
+                       C216 68 212 72 206 72
+                       L22 72
+                       C15 72 12 67 13 61
+                       L25 58 Z" fill="url(#carBody)" />
 
-            <!-- highlights -->
-            <path d="M38 52 C50 37 66 32 92 32" stroke="rgba(255,255,255,0.22)" stroke-width="4"
-              stroke-linecap="round" />
-            <path d="M112 24 L152 24" stroke="rgba(255,255,255,0.18)" stroke-width="4" stroke-linecap="round" />
+              <path d="M38 52 C50 37 66 32 92 32" stroke="rgba(255,255,255,0.22)" stroke-width="4"
+                stroke-linecap="round" />
+              <path d="M112 24 L152 24" stroke="rgba(255,255,255,0.18)" stroke-width="4" stroke-linecap="round" />
 
-            <!-- windows -->
-            <path d="M98 34
-                         C105 25 115 21 128 21
-                         L150 21
-                         C160 21 168 25 175 34
-                         Z" fill="url(#glass)" opacity="0.95" />
+              <path d="M98 34
+                             C105 25 115 21 128 21
+                             L150 21
+                             C160 21 168 25 175 34
+                             Z" fill="url(#glass)" opacity="0.95" />
 
-            <!-- headlights -->
-            <circle cx="26" cy="60" r="4" fill="rgba(255,255,255,0.85)" />
-            <circle cx="26" cy="60" r="10" fill="rgba(255,255,255,0.10)" />
+              <circle cx="26" cy="60" r="4" fill="rgba(255,255,255,0.85)" />
+              <circle cx="26" cy="60" r="10" fill="rgba(255,255,255,0.10)" />
 
-            <!-- wheels -->
-            <g class="wheel">
-              <circle cx="70" cy="72" r="14" fill="rgba(10,12,20,0.9)" />
-              <circle cx="70" cy="72" r="9" fill="rgba(255,255,255,0.22)" />
-              <circle cx="70" cy="72" r="3" fill="rgba(255,255,255,0.55)" />
+              <g class="wheel">
+                <circle cx="70" cy="72" r="14" fill="rgba(10,12,20,0.9)" />
+                <circle cx="70" cy="72" r="9" fill="rgba(255,255,255,0.22)" />
+                <circle cx="70" cy="72" r="3" fill="rgba(255,255,255,0.55)" />
+              </g>
+              <g class="wheel">
+                <circle cx="160" cy="72" r="14" fill="rgba(10,12,20,0.9)" />
+                <circle cx="160" cy="72" r="9" fill="rgba(255,255,255,0.22)" />
+                <circle cx="160" cy="72" r="3" fill="rgba(255,255,255,0.55)" />
+              </g>
+
+              <rect x="152" y="38" width="22" height="16" rx="3" fill="rgba(255,255,255,0.20)"
+                stroke="rgba(255,255,255,0.25)" />
+              <path d="M152 46 L174 46" stroke="rgba(255,255,255,0.25)" />
             </g>
-            <g class="wheel">
-              <circle cx="160" cy="72" r="14" fill="rgba(10,12,20,0.9)" />
-              <circle cx="160" cy="72" r="9" fill="rgba(255,255,255,0.22)" />
-              <circle cx="160" cy="72" r="3" fill="rgba(255,255,255,0.55)" />
-            </g>
-
-            <!-- small package box (transport vibe) -->
-            <rect x="152" y="38" width="22" height="16" rx="3" fill="rgba(255,255,255,0.20)"
-              stroke="rgba(255,255,255,0.25)" />
-            <path d="M152 46 L174 46" stroke="rgba(255,255,255,0.25)" />
           </svg>
         </div>
 


### PR DESCRIPTION


## 📌 Related Issue
Fixes #1309 

---

## Description of Changes
Fixed the 404 page animation
The car now faces the direction in which it moves
The lane animation is opposition to the car moving direction

---

## Type of Change
- [x] 🐛 Bug Fix  
- [x] 🔧 Feature Modification  
- [ ] ✨ New Feature  
- [ ] 🧹 Maintenance / Cleanup / Documentation Update  
- [x] 🎨 UI/UX or Design Update  
- [ ] 📘 Resource / Content Addition  
- [ ] Other  (please describe):

---
## Testing
Describe the tests you ran to verify your changes.
- [x] Tested locally
- [x] No tests required
---
## 📸 Screenshots / Video

https://github.com/user-attachments/assets/33770dc4-1519-4c1a-8959-bee57f43a851




---

## ✅ Checklist
- [x] I’ve read the **CONTRIBUTING.md** guidelines.  
- [x] My code follows the project’s conventions.  
- [x] I’ve linked the related issue correctly.  
- [x] I’ve tested my changes locally.  
- [x] I’ve added or updated documentation/comments if needed.  
- [x] My PR title follows the branch & commit naming conventions.  
- [x] My changes introduce no new warnings or errors.  
- [x] I’ve performed a self-review of my work.  

---