### PR TITLE
fix: inverted arrow toggle in on this page popup

### DIFF
--- a/frontend/js/modules/sticky-toc.js
+++ b/frontend/js/modules/sticky-toc.js
@@ -231,7 +231,7 @@
       color: '#fff',
       fontSize: '14px',
       transition: 'transform 0.3s ease',
-      transform: isCollapsed ? 'rotate(180deg)' : 'rotate(0deg)'
+      transform: isCollapsed ? 'rotate(0deg)' : 'rotate(180deg)'
     });
     toggleTab.appendChild(arrow);
 
@@ -402,10 +402,10 @@
 
       if (collapsed) {
         wrapper.style.transform = 'translateX(calc(100% - 32px))';
-        arrow.style.transform = 'rotate(180deg)';
+        arrow.style.transform = 'rotate(0deg)';
       } else {
         wrapper.style.transform = 'translateX(0)';
-        arrow.style.transform = 'rotate(0deg)';
+        arrow.style.transform = 'rotate(180deg)';
       }
     }
 


### PR DESCRIPTION
# Pull Request — Car Transport Service

Thank you for contributing to **Car Transport Service**!  
Please fill out the following details to help us review your PR efficiently.

---

## 📌 Related Issue
Fixes #1340 

---

## Description of Changes
Describe your changes and their purpose.  

Fixed a visual bug where the indicator/toggle arrow icon in the "On this page" floating table of contents menu was completely inverted. 

- Swapped the rotation logic (`0deg` and `180deg`) in `frontend/js/modules/sticky-toc.js` across both states.
- The arrow now correctly points **right** (toward the screen edge) when the menu is open to signal a collapse action, and points **left** (toward the content) when the menu is collapsed to signal an expand action.

---

## Type of Change
- [x] 🐛 Bug Fix  
- [ ] 🔧 Feature Modification  
- [ ] ✨ New Feature  
- [ ] 🧹 Maintenance / Cleanup / Documentation Update  
- [x] 🎨 UI/UX or Design Update  
- [ ] 📘 Resource / Content Addition  
- [ ] Other  (please describe):

---
## Testing
Describe the tests you ran to verify your changes.
- [x] Tested locally
- [ ] No tests required
---
## 📸 Screenshots / Video
### Before:

<img width="683" height="748" alt="image" src="https://github.com/user-attachments/assets/1331be29-c5a5-4e3e-8ae9-9616f107be6c" />

### After:
<img width="402" height="390" alt="image" src="https://github.com/user-attachments/assets/7f8c4b5c-7dca-43c8-ab9c-dff6ff2fff68" />
<img width="162" height="190" alt="image" src="https://github.com/user-attachments/assets/8a49ac76-9fe4-483d-acdb-491355b264c9" />

---

## ✅ Checklist
- [x] I’ve read the **CONTRIBUTING.md** guidelines.  
- [x] My code follows the project’s conventions.  
- [x] I’ve linked the related issue correctly.  
- [x] I’ve tested my changes locally.  
- [ ] I’ve added or updated documentation/comments if needed.  
- [x] My PR title follows the branch & commit naming conventions.  
- [x] My changes introduce no new warnings or errors.  
- [x] I’ve performed a self-review of my work.  

---

## 💬 Additional Notes (Optional)
_Add any context, dependencies, or questions for reviewers._
